### PR TITLE
Fixes broken image (Software architecture) in Tech page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# IDE generated files #
+#######################
+.idea

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 			 	"@core:initial-content-6",
 			 	"@core:initial-content-7",
 			 	"@core:initial-content-8",
-			 	"@core:initial-content-9"
+			 	"@core:initial-content-9",
+				"@core:initial-content-10"
 			],
 
 			"core:initial-content-1": "wp post update 2 --post_title='Tech' page-tech.html",
@@ -33,7 +34,8 @@
 			"core:initial-content-6": "wp option update page_on_front 5",
 			"core:initial-content-7": "wp post update 4 --post_status=publish",
 			"core:initial-content-8": "wp post update 5 --post_status=publish",
-			"core:initial-content-9": "wp post update 6 --post_status=publish"
+			"core:initial-content-9": "wp post update 6 --post_status=publish",
+			"core:initial-content-10": "wp media import vendor/greenpeace/planet4-content-default/assets/software-architecture.png --post_id=2 --title='Software architecture'"
 
 		}
 }

--- a/page-tech.html
+++ b/page-tech.html
@@ -1,6 +1,6 @@
 <h1>Tech</h1>
 
-<img src="assets/software-architecture.png" alt="software-architecture" width="624" height="444" />
+<img src="/public/wp-content/uploads/2017/05/software-architecture.png" alt="software-architecture" width="624" height="444" />
 
 <p>Thanks for Planet 4. We'd love your help in the technical track. We have a lot to do, but at the moment, we're still setting up infrastructures so that technical folks can contribute meaningfully. 
 </p>


### PR DESCRIPTION
If you have already installed the site then do the following in order to fix the broken image:

1. composer update greenpeace/planet4-content-default
2. composer run-script core:initial-content-1 -d vendor/greenpeace/planet4-content-default
3. composer run-script core:initial-content-10 -d vendor/greenpeace/planet4-content-default
   - If you see this error: No support for generating images found. Please install the Imagick or GD PHP extensions.
     Then do:
       for debian/ubuntu: sudo apt-get install php-imagick
       for mac: brew install phpXX-imagick (XX is your php version e.g. 56 for php5.6)
     Then try step 3 again