### PR TITLE
PLANET-2093 - Update Font-Awesome to 5.0.10

### DIFF
--- a/initialize-content.php
+++ b/initialize-content.php
@@ -109,22 +109,22 @@ $menus = [
 			[
 				'name'    => 'Twitter',
 				'url'     => 'http://twitter.com',
-				'classes' => 'fa fa-twitter',
+				'classes' => 'fab fa-twitter',
 			],
 			[
 				'name'    => 'Facebook',
 				'url'     => 'http://facebook.com',
-				'classes' => 'fa fa-facebook-official',
+				'classes' => 'fab fa-facebook',
 			],
 			[
 				'name'    => 'Youtube',
 				'url'     => 'http://youtube.com',
-				'classes' => 'fa fa-youtube-play',
+				'classes' => 'fab fa-youtube',
 			],
 			[
 				'name'    => 'Instagram',
 				'url'     => 'http://instagram.com',
-				'classes' => 'fa fa-instagram',
+				'classes' => 'fab fa-instagram',
 			],
 		],
 	],


### PR DESCRIPTION
This should be merged along with greenpeace/planet4-master-theme#415

Font-Awesome has spitted the fonts in 3 sets. Social icons are part of the "brands" set so we need to change the class from `.fa` to `.fab`.